### PR TITLE
Android app to run python projects

### DIFF
--- a/AndroidPythonRunner/app/build.gradle
+++ b/AndroidPythonRunner/app/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id "com.android.application"
+    id "com.chaquo.python"
+}
+
+android {
+    namespace "com.example.pythonrunner"
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.pythonrunner"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging true
+        }
+    }
+}
+
+dependencies {
+    implementation "androidx.appcompat:appcompat:1.7.0"
+    implementation "com.google.android.material:material:1.12.0"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+}
+
+python {
+    // Configure embedded Python and pip packages for Chaquopy
+    pip {
+        install "pip==23.2.1"
+        install "requests==2.32.3"
+        // numpy can be heavy; include only if you need it for projects
+        // install "numpy==1.26.4"
+    }
+}

--- a/AndroidPythonRunner/app/proguard-rules.pro
+++ b/AndroidPythonRunner/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Keep Chaquopy Python classes
+-keep class com.chaquo.python.** { *; }

--- a/AndroidPythonRunner/app/src/main/AndroidManifest.xml
+++ b/AndroidPythonRunner/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <application
+        android:allowBackup="true"
+        android:label="AndroidPythonRunner"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/AndroidPythonRunner/app/src/main/java/com/example/pythonrunner/AndroidDocuments.java
+++ b/AndroidPythonRunner/app/src/main/java/com/example/pythonrunner/AndroidDocuments.java
@@ -1,0 +1,92 @@
+package com.example.pythonrunner;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.DocumentsContract;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AndroidDocuments {
+
+    // Lists children of the ROOT of the picked tree.
+    public static List<Uri> listChildren(Context context, Uri treeUri) {
+        List<Uri> results = new ArrayList<>();
+        Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri,
+                DocumentsContract.getTreeDocumentId(treeUri));
+        Cursor c = context.getContentResolver().query(childrenUri,
+                new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                        DocumentsContract.Document.COLUMN_MIME_TYPE,
+                        DocumentsContract.Document.COLUMN_DISPLAY_NAME},
+                null, null, null);
+        if (c != null) {
+            try {
+                while (c.moveToNext()) {
+                    String documentId = c.getString(0);
+                    Uri docUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId);
+                    results.add(docUri);
+                }
+            } finally {
+                c.close();
+            }
+        }
+        return results;
+    }
+
+    // Lists children of an arbitrary directory within the same tree, given its documentId.
+    public static List<Uri> listChildren(Context context, Uri treeUri, String parentDocumentId) {
+        List<Uri> results = new ArrayList<>();
+        Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, parentDocumentId);
+        Cursor c = context.getContentResolver().query(childrenUri,
+                new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                        DocumentsContract.Document.COLUMN_MIME_TYPE,
+                        DocumentsContract.Document.COLUMN_DISPLAY_NAME},
+                null, null, null);
+        if (c != null) {
+            try {
+                while (c.moveToNext()) {
+                    String documentId = c.getString(0);
+                    Uri docUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId);
+                    results.add(docUri);
+                }
+            } finally {
+                c.close();
+            }
+        }
+        return results;
+    }
+
+    public static boolean isDirectory(Context context, Uri docUri) {
+        Cursor c = context.getContentResolver().query(docUri,
+                new String[]{DocumentsContract.Document.COLUMN_MIME_TYPE},
+                null, null, null);
+        if (c != null) {
+            try {
+                if (c.moveToFirst()) {
+                    String mime = c.getString(0);
+                    return DocumentsContract.Document.MIME_TYPE_DIR.equals(mime);
+                }
+            } finally {
+                c.close();
+            }
+        }
+        return false;
+    }
+
+    public static String getName(Context context, Uri docUri) {
+        Cursor c = context.getContentResolver().query(docUri,
+                new String[]{DocumentsContract.Document.COLUMN_DISPLAY_NAME},
+                null, null, null);
+        if (c != null) {
+            try {
+                if (c.moveToFirst()) {
+                    return c.getString(0);
+                }
+            } finally {
+                c.close();
+            }
+        }
+        return "";
+    }
+}

--- a/AndroidPythonRunner/app/src/main/java/com/example/pythonrunner/MainActivity.java
+++ b/AndroidPythonRunner/app/src/main/java/com/example/pythonrunner/MainActivity.java
@@ -1,0 +1,175 @@
+package com.example.pythonrunner;
+
+import android.Manifest;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.DocumentsContract;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class MainActivity extends AppCompatActivity {
+
+    private TextView txtPath;
+    private TextView txtOutput;
+    private Uri pickedTreeUri = null;
+
+    private final ActivityResultLauncher<String> requestPermissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                if (!isGranted) {
+                    Toast.makeText(this, "Storage permission denied", Toast.LENGTH_SHORT).show();
+                }
+            });
+
+    private final ActivityResultLauncher<Uri> openTreeLauncher =
+            registerForActivityResult(new ActivityResultContracts.OpenDocumentTree(), new ActivityResultCallback<Uri>() {
+                @Override
+                public void onActivityResult(Uri uri) {
+                    if (uri != null) {
+                        pickedTreeUri = uri;
+                        txtPath.setText(uri.toString());
+                        getContentResolver().takePersistableUriPermission(uri,
+                                Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                    }
+                }
+            });
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        txtPath = findViewById(R.id.txtPath);
+        txtOutput = findViewById(R.id.txtOutput);
+        Button btnSelect = findViewById(R.id.btnSelect);
+        Button btnRun = findViewById(R.id.btnRun);
+
+        if (! Python.isStarted()) {
+            Python.start(new AndroidPlatform(this));
+        }
+
+        if (Build.VERSION.SDK_INT < 33) {
+            requestPermissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE);
+        }
+
+        btnSelect.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                openTreeLauncher.launch(null);
+            }
+        });
+
+        btnRun.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                runSelectedProject();
+            }
+        });
+    }
+
+    private void runSelectedProject() {
+        if (pickedTreeUri == null) {
+            Toast.makeText(this, "Select a project folder first", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        File appFiles = new File(getFilesDir(), "projects");
+        if (!appFiles.exists()) appFiles.mkdirs();
+
+        File projectDir = new File(appFiles, "selected");
+        if (projectDir.exists()) deleteRecursively(projectDir);
+        projectDir.mkdirs();
+
+        copySelectedTreeToLocal(pickedTreeUri, projectDir);
+
+        File mainPy = new File(projectDir, "main.py");
+        if (!mainPy.exists()) {
+            appendOutput("main.py not found in the selected folder\n");
+            return;
+        }
+
+        try {
+            Python py = Python.getInstance();
+            PyObject runner = py.getModule("py_runner");
+            PyObject result = runner.callAttr("run_script", mainPy.getAbsolutePath());
+            appendOutput(result.toString() + "\n");
+        } catch (Exception e) {
+            appendOutput("Error: " + e.getMessage() + "\n");
+        }
+    }
+
+    private void appendOutput(@NonNull String text) {
+        runOnUiThread(() -> txtOutput.append(text));
+    }
+
+    private void copySelectedTreeToLocal(Uri treeUri, File destDir) {
+        try {
+            Uri rootDocUri = DocumentsContract.buildDocumentUriUsingTree(
+                    treeUri, DocumentsContract.getTreeDocumentId(treeUri));
+            copyDocumentDirectory(treeUri, rootDocUri, destDir);
+        } catch (Exception e) {
+            appendOutput("Copy error: " + e.getMessage() + "\n");
+        }
+    }
+
+    private void copyDocumentDirectory(Uri treeUri, Uri parentDocUri, File destDir) {
+        try {
+            String parentId = DocumentsContract.getDocumentId(parentDocUri);
+            for (Uri childDoc : AndroidDocuments.listChildren(this, treeUri, parentId)) {
+                String name = AndroidDocuments.getName(this, childDoc);
+                boolean isDir = AndroidDocuments.isDirectory(this, childDoc);
+                if (isDir) {
+                    File sub = new File(destDir, name);
+                    sub.mkdirs();
+                    copyDocumentDirectory(treeUri, childDoc, sub);
+                } else {
+                    copySingleFile(childDoc, new File(destDir, name));
+                }
+            }
+        } catch (Exception e) {
+            appendOutput("Copy error: " + e.getMessage() + "\n");
+        }
+    }
+
+    private void copySingleFile(Uri uri, File dest) throws IOException {
+        try (InputStream in = getContentResolver().openInputStream(uri);
+             OutputStream out = new FileOutputStream(dest)) {
+            byte[] buf = new byte[8192];
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                out.write(buf, 0, len);
+            }
+        }
+    }
+
+    private void deleteRecursively(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}

--- a/AndroidPythonRunner/app/src/main/python/py_runner.py
+++ b/AndroidPythonRunner/app/src/main/python/py_runner.py
@@ -1,0 +1,31 @@
+import io
+import os
+import runpy
+import sys
+import traceback
+
+
+def run_script(main_path: str) -> str:
+    """
+    Run the provided main.py script in-process while capturing stdout/stderr.
+    Returns combined output. Sets CWD to the script directory.
+    """
+    buffer = io.StringIO()
+    old_stdout, old_stderr, old_cwd, old_argv = sys.stdout, sys.stderr, os.getcwd(), sys.argv
+    try:
+        sys.stdout = buffer
+        sys.stderr = buffer
+        script_dir = os.path.dirname(main_path)
+        if script_dir:
+            os.chdir(script_dir)
+        sys.argv = [main_path]
+        runpy.run_path(main_path, run_name="__main__")
+    except SystemExit as exc:
+        buffer.write(f"\n[exit] {exc}\n")
+    except Exception:
+        traceback.print_exc(file=buffer)
+    finally:
+        sys.stdout, sys.stderr = old_stdout, old_stderr
+        os.chdir(old_cwd)
+        sys.argv = old_argv
+    return buffer.getvalue()

--- a/AndroidPythonRunner/app/src/main/res/layout/activity_main.xml
+++ b/AndroidPythonRunner/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/btnSelect"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/select_project" />
+
+    <TextView
+        android:id="@+id/txtPath"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="" />
+
+    <Button
+        android:id="@+id/btnRun"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/run_project" />
+
+    <TextView
+        android:id="@+id/txtOutput"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="12dp"
+        android:background="#222"
+        android:padding="8dp"
+        android:textColor="#0f0"
+        android:textIsSelectable="true" />
+
+</LinearLayout>

--- a/AndroidPythonRunner/app/src/main/res/values/strings.xml
+++ b/AndroidPythonRunner/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">AndroidPythonRunner</string>
+    <string name="select_project">Select Python Project</string>
+    <string name="run_project">Run Project</string>
+    <string name="output">Output</string>
+</resources>

--- a/AndroidPythonRunner/build.gradle
+++ b/AndroidPythonRunner/build.gradle
@@ -1,0 +1,23 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://chaquo.com/maven" }
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.5.2"
+        classpath "com.chaquo.python:gradle:15.0.1"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://chaquo.com/maven" }
+    }
+}
+
+tasks.register("clean", Delete) {
+    delete(rootProject.buildDir)
+}

--- a/AndroidPythonRunner/gradle.properties
+++ b/AndroidPythonRunner/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+android.enableJetifier=true

--- a/AndroidPythonRunner/settings.gradle
+++ b/AndroidPythonRunner/settings.gradle
@@ -1,0 +1,20 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven { url "https://chaquo.com/maven" }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://chaquo.com/maven" }
+    }
+}
+
+rootProject.name = "AndroidPythonRunner"
+include(":app")


### PR DESCRIPTION
Add an Android application that embeds a Python runtime to select and execute Python projects.

This application uses Chaquopy to run Python scripts, allowing users to pick a project folder via the Storage Access Framework (SAF), copy it locally, and execute its `main.py` while capturing stdout/stderr.

---
<a href="https://cursor.com/background-agent?bcId=bc-db96e787-342f-4260-88f5-0b2d46d48247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db96e787-342f-4260-88f5-0b2d46d48247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

